### PR TITLE
Make the pod container name 'docling-serve'

### DIFF
--- a/internal/reconcilers/deployment.go
+++ b/internal/reconcilers/deployment.go
@@ -48,7 +48,7 @@ func (r *DeploymentReconciler) Reconcile(ctx context.Context, doclingServe *v1al
 				Containers: []corev1.Container{
 					{
 						Image: doclingServe.Spec.APIServer.Image,
-						Name:  "docling-serv",
+						Name:  "docling-serve",
 						Command: []string{
 							"docling-serve",
 							"run",


### PR DESCRIPTION
A 'docling-serv' was missed in the rename.

Signed-off-by: Brad P. Crochet <brad@redhat.com>
