### PR TITLE
Rename controller package to manager

### DIFF
--- a/cmd/internal/manager/main.go
+++ b/cmd/internal/manager/main.go
@@ -1,4 +1,4 @@
-package controller
+package manager
 
 import (
 	"context"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"os"
 
-	"github.io/opdev/docling-operator/cmd/internal/controller"
+	"github.io/opdev/docling-operator/cmd/internal/manager"
 )
 
 func main() {
-	if err := controller.Run(context.TODO()); err != nil {
+	if err := manager.Run(context.TODO()); err != nil {
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
The name of the package makes more sense to be manager and not
controller.

Signed-off-by: Brad P. Crochet <brad@redhat.com>
