### PR TITLE
adding make bundle to ci to ensure proper csv generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Manifests
         run: make manifests && git diff --exit-code
 
+      - name: Bundle
+        run: make bundle && git diff --exit-code
+
       - name: Tidy
         run: make tidy
 


### PR DESCRIPTION
## Motivation
When running `make bundle` locally I noticed that the base CSV file was being updated, due to files missing from the generation commit after API changes.

## Change
Add `make bundle` to the list of checks in CI for PRs and check the git diff.


- Relates: #44 